### PR TITLE
add @andrinoff to codeowners for pr reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @plazen/maintainers
+* @andrinoff


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file by adding `@andrinoff` as a code owner.