### PR TITLE
fix(login): remove apple from providers

### DIFF
--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -30,36 +30,6 @@ const socialProviders = [
     bgColor: "bg-indigo-600 hover:bg-indigo-700",
     name: "Discord",
   },
-  // {
-  //   id: "twitter",
-  //   icon: Twitter,
-  //   bgColor: "bg-blue-500 hover:bg-blue-600",
-  //   name: "Twitter",
-  // },
-  // {
-  //   id: "facebook",
-  //   icon: Facebook,
-  //   bgColor: "bg-blue-600 hover:bg-blue-700",
-  //   name: "Facebook",
-  // },
-  // {
-  //   id: "linkedin_oidc",
-  //   icon: Linkedin,
-  //   bgColor: "bg-blue-700 hover:bg-blue-800",
-  //   name: "LinkedIn",
-  // },
-  // {
-  //   id: "azure",
-  //   icon: Mail,
-  //   bgColor: "bg-blue-500 hover:bg-blue-600",
-  //   name: "Microsoft",
-  // },
-  {
-    id: "apple",
-    icon: FaApple,
-    bgColor: "bg-black hover:bg-gray-900",
-    name: "Apple",
-  },
 ];
 
 export default function LoginPage() {
@@ -107,11 +77,6 @@ export default function LoginPage() {
           | "github"
           | "google"
           | "discord"
-          // | "twitter"
-          // | "facebook"
-          // | "linkedin_oidc"
-          // | "azure"
-          | "apple",
       });
       if (error) throw error;
     } catch (error) {


### PR DESCRIPTION
This pull request simplifies the social login options on the `LoginPage` by removing support for several providers and streamlining the provider configuration. The changes focus on cleaning up both the UI and the authentication logic.

**Social login provider cleanup:**

* Removed commented-out configurations for Twitter, Facebook, LinkedIn, and Microsoft (Azure) from the `socialProviders` array in `LoginPage.tsx` to reduce clutter and clarify which providers are currently supported.
* Removed the "apple" provider from the list of supported authentication providers in the login handler, ensuring consistency between the UI and backend logic.