### PR TITLE
feat: cache timetableapp & accountpage (ttl: 5) (#127)

### DIFF
--- a/src/app/account/AccountPage.tsx
+++ b/src/app/account/AccountPage.tsx
@@ -175,6 +175,49 @@ export default function AccountPage() {
   );
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // Account page client-side cache helpers (sessionStorage, TTL 5 minutes)
+  const ACCOUNT_CACHE_TTL_MS = 5 * 60 * 1000;
+  const accountCacheKey = (name: string) => `plazen_account_${name}`;
+
+  const readCache = (name: string) => {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = sessionStorage.getItem(accountCacheKey(name));
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return null;
+      if (Date.now() - (parsed.ts || 0) > ACCOUNT_CACHE_TTL_MS) {
+        sessionStorage.removeItem(accountCacheKey(name));
+        return null;
+      }
+      return parsed.value ?? null;
+    } catch (err) {
+      console.error("Account cache read error:", err);
+      return null;
+    }
+  };
+
+  const writeCache = (name: string, value: any) => {
+    if (typeof window === "undefined") return;
+    try {
+      sessionStorage.setItem(
+        accountCacheKey(name),
+        JSON.stringify({ ts: Date.now(), value }),
+      );
+    } catch (err) {
+      console.error("Account cache write error:", err);
+    }
+  };
+
+  const invalidateCache = (name: string) => {
+    if (typeof window === "undefined") return;
+    try {
+      sessionStorage.removeItem(accountCacheKey(name));
+    } catch (err) {
+      console.error("Account cache invalidate error:", err);
+    }
+  };
+
   const fetchAvatarSignedUrl = useCallback(async (path: string) => {
     try {
       const response = await fetch(
@@ -285,7 +328,40 @@ export default function AccountPage() {
           }
         }
 
-        await Promise.all([fetchSettings(), fetchStats(), fetchSubscription()]);
+        // Try to read cached account data (non-blocking, show immediately if present)
+        const cachedSettings = readCache("settings");
+        const cachedStats = readCache("stats");
+        const cachedSubscription = readCache("subscription");
+
+        if (cachedSettings) {
+          setNotifications({
+            notifications: cachedSettings.notifications ?? true,
+          });
+        }
+        if (cachedStats) {
+          setStats(cachedStats);
+        }
+        if (cachedSubscription) {
+          setSubscription(cachedSubscription);
+        }
+
+        // Background refresh to keep cache fresh. Each fetch returns its data which we persist.
+        (async () => {
+          try {
+            const [freshSettings, freshStats, freshSubscription] =
+              await Promise.all([
+                fetchSettings(),
+                fetchStats(),
+                fetchSubscription(),
+              ]);
+            if (freshSettings) writeCache("settings", freshSettings);
+            if (freshStats) writeCache("stats", freshStats);
+            if (freshSubscription)
+              writeCache("subscription", freshSubscription);
+          } catch (err) {
+            console.error("Failed background refresh of account data:", err);
+          }
+        })();
       } else {
         router.push("/login");
       }
@@ -302,10 +378,12 @@ export default function AccountPage() {
       if (res.ok) {
         const data = await res.json();
         setSubscription(data);
+        return data;
       }
     } catch (error) {
       console.error("Failed to fetch subscription:", error);
     }
+    return null;
   };
 
   const fetchSettings = async () => {
@@ -314,10 +392,12 @@ export default function AccountPage() {
       if (response.ok) {
         const data = await response.json();
         setNotifications({ notifications: data.notifications ?? true });
+        return data;
       }
     } catch (error) {
       console.error("Failed to fetch settings:", error);
     }
+    return null;
   };
 
   const fetchStats = async () => {
@@ -340,16 +420,20 @@ export default function AccountPage() {
               )
             : 60;
 
-        setStats({
+        const computedStats = {
           totalTasks: tasks.length,
           completedTasks: completed,
           dailyStreak: calculateDailyStreak(tasks),
           avgTaskDuration: avgDuration,
-        });
+        };
+
+        setStats(computedStats);
+        return computedStats;
       }
     } catch (error) {
       console.error("Failed to fetch stats:", error);
     }
+    return null;
   };
 
   const calculateDailyStreak = (
@@ -584,6 +668,9 @@ export default function AccountPage() {
         body: JSON.stringify({ [key]: value }),
       });
       if (!response.ok) throw new Error("Failed to update settings");
+
+      // Invalidate cached settings so next visit / background refresh will fetch fresh settings
+      invalidateCache("settings");
     } catch (error) {
       console.error("Failed to save settings:", error);
       setNotifications((prev) => ({ ...prev, [key]: !value }));

--- a/src/app/schedule/TimetableApp.tsx
+++ b/src/app/schedule/TimetableApp.tsx
@@ -94,6 +94,41 @@ export default function TimetableApp() {
   // Track the current date string to avoid updating tasks for stale dates
   const currentDateRef = React.useRef<string>("");
 
+  // Simple sessionStorage-based cache for tasks per date (TTL: 5 minutes)
+  const CACHE_TTL_MS = 5 * 60 * 1000;
+  const getCacheKey = (dateString: string) => `plazen_tasks_${dateString}`;
+
+  const getCachedTasksForDate = (dateString: string) => {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = sessionStorage.getItem(getCacheKey(dateString));
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return null;
+      if (Date.now() - (parsed.ts || 0) > CACHE_TTL_MS) {
+        // expired
+        sessionStorage.removeItem(getCacheKey(dateString));
+        return null;
+      }
+      return parsed.tasks ?? null;
+    } catch (err) {
+      // Corrupt data or unavailable - ignore cache
+      return null;
+    }
+  };
+
+  const setCachedTasksForDate = (dateString: string, tasksToCache: any[]) => {
+    if (typeof window === "undefined") return;
+    try {
+      sessionStorage.setItem(
+        getCacheKey(dateString),
+        JSON.stringify({ ts: Date.now(), tasks: tasksToCache }),
+      );
+    } catch (err) {
+      // ignore storage errors
+    }
+  };
+
   const fetchTasks = useCallback(
     async (selectedDate: Date, skipSync = false) => {
       setTasksLoading(true);
@@ -107,6 +142,83 @@ export default function TimetableApp() {
         // Update the ref to track the current date being fetched
         currentDateRef.current = dateString;
 
+        // If we have a recent cached copy in sessionStorage, use it immediately
+        const cached = getCachedTasksForDate(dateString);
+        if (cached) {
+          if (currentDateRef.current === dateString) {
+            setTasks(cached);
+          }
+          setTasksLoading(false);
+
+          // Fire a background refresh to keep cache up-to-date (non-blocking)
+          (async () => {
+            try {
+              const response = await fetch(
+                `/api/tasks?date=${dateString}&timezoneOffset=${timezoneOffset}`,
+              );
+              if (response.ok) {
+                const fetchedTasks = await response.json();
+                setCachedTasksForDate(dateString, fetchedTasks);
+                if (currentDateRef.current === dateString) {
+                  setTasks(fetchedTasks);
+                }
+              }
+            } catch (err) {
+              console.error("Failed background fetch tasks:", err);
+            }
+          })();
+
+          // Still trigger calendar sync in the background if requested
+          if (!skipSync) {
+            fetch("/api/calendars/sync-all", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              // Pass timezoneOffset so the server knows the exact local 24h window
+              body: JSON.stringify({ date: dateString, timezoneOffset }),
+            })
+              .then((syncResponse) => {
+                if (syncResponse.ok) {
+                  return syncResponse.json();
+                }
+                return null;
+              })
+              .then((syncResult) => {
+                // Only refetch if sync was successful and had calendar sources
+                // AND the user is still viewing the same date
+                if (
+                  syncResult &&
+                  syncResult.synced > 0 &&
+                  currentDateRef.current === dateString
+                ) {
+                  // Refetch tasks to get updated external events (skip sync to avoid loop)
+                  fetch(
+                    `/api/tasks?date=${dateString}&timezoneOffset=${timezoneOffset}`,
+                  )
+                    .then((res) => (res.ok ? res.json() : null))
+                    .then((updatedTasks) => {
+                      // Double-check the date is still current before updating
+                      if (
+                        updatedTasks &&
+                        currentDateRef.current === dateString
+                      ) {
+                        setTasks(updatedTasks);
+                        setCachedTasksForDate(dateString, updatedTasks);
+                      }
+                    })
+                    .catch((err) => {
+                      console.error("Failed to refetch tasks after sync:", err);
+                    });
+                }
+              })
+              .catch((err) => {
+                console.error("Failed to sync calendars:", err);
+              });
+          }
+
+          return;
+        }
+
+        // No valid cache, fetch from server
         const response = await fetch(
           `/api/tasks?date=${dateString}&timezoneOffset=${timezoneOffset}`,
         );
@@ -114,6 +226,9 @@ export default function TimetableApp() {
           throw new Error("Failed to fetch tasks");
         }
         const fetchedTasks = await response.json();
+
+        // Cache the fresh result
+        setCachedTasksForDate(dateString, fetchedTasks);
 
         // Only update if this is still the current date
         if (currentDateRef.current === dateString) {
@@ -152,6 +267,7 @@ export default function TimetableApp() {
                     // Double-check the date is still current before updating
                     if (updatedTasks && currentDateRef.current === dateString) {
                       setTasks(updatedTasks);
+                      setCachedTasksForDate(dateString, updatedTasks);
                     }
                   })
                   .catch((err) => {
@@ -292,7 +408,15 @@ export default function TimetableApp() {
       });
       if (!response.ok) throw new Error("Failed to add task");
       const addedTask = await response.json();
-      setTasks((prev) => [...prev, addedTask]);
+
+      // Update tasks state and cache atomically
+      const cacheDate = toLocalISOString(date || new Date());
+      setTasks((prev) => {
+        const updated = [...prev, addedTask];
+        setCachedTasksForDate(cacheDate, updated);
+        return updated;
+      });
+
       setIsAddTaskModalOpen(false);
     } catch (err) {
       setError(
@@ -312,7 +436,15 @@ export default function TimetableApp() {
       });
       if (!response.ok) throw new Error("Failed to update task status");
       const updatedTask = await response.json();
-      setTasks(tasks.map((task) => (task.id === taskId ? updatedTask : task)));
+
+      const cacheDate = toLocalISOString(date || new Date());
+      setTasks((prev) => {
+        const updated = prev.map((task) =>
+          task.id === taskId ? updatedTask : task,
+        );
+        setCachedTasksForDate(cacheDate, updated);
+        return updated;
+      });
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "An unknown error occurred",
@@ -321,7 +453,12 @@ export default function TimetableApp() {
   };
 
   const handleDeleteTask = async (taskId: string) => {
-    setTasks(tasks.filter((task) => task.id !== taskId));
+    const cacheDate = toLocalISOString(date || new Date());
+    setTasks((prev) => {
+      const updated = prev.filter((task) => task.id !== taskId);
+      setCachedTasksForDate(cacheDate, updated);
+      return updated;
+    });
     try {
       const response = await fetch("/api/tasks", {
         method: "DELETE",


### PR DESCRIPTION
This pull request introduces client-side caching for both the Account and Timetable (Schedule) pages to improve performance and responsiveness. By leveraging `sessionStorage` with a 5-minute TTL, the app can immediately display cached data while refreshing it in the background, resulting in a faster and smoother user experience. The cache is updated or invalidated as appropriate when data is changed.

**Account Page caching enhancements:**

- Added helper functions (`readCache`, `writeCache`, `invalidateCache`) to manage account-related data in `sessionStorage` with a 5-minute TTL.
- On page load, attempts to read cached settings, stats, and subscription data and displays them immediately if present. Then, fetches fresh data in the background and updates the cache.
- Modified fetch functions (`fetchSubscription`, `fetchSettings`, `fetchStats`) to return fetched data so it can be cached after retrieval. [[1]](diffhunk://#diff-4684aa0555e508b5436f512c0465c6fe0e5f297c8e712925dde9370620cff871R381-R386) [[2]](diffhunk://#diff-4684aa0555e508b5436f512c0465c6fe0e5f297c8e712925dde9370620cff871R395-R400) [[3]](diffhunk://#diff-4684aa0555e508b5436f512c0465c6fe0e5f297c8e712925dde9370620cff871L343-R436)
- Invalidates the cached settings after a successful settings update to ensure stale data is not shown on future visits.

**Timetable (Schedule) Page caching enhancements:**

- Introduced a sessionStorage-based cache for tasks per date, with helper functions and a 5-minute TTL.
- On fetching tasks, checks for a cached copy and displays it immediately if available, while performing a background refresh to update both the UI and cache. Also, syncs with external calendars in the background.
- Caches freshly fetched tasks after a successful fetch from the server.
- Updates the cache whenever tasks are modified (added, updated, or deleted) to keep the cache in sync with the UI. [[1]](diffhunk://#diff-3e4602d91e0bd8b7fc7fff02fb9629c9cd245c056b27f06e9973f5f2d3fb44abR270) [[2]](diffhunk://#diff-3e4602d91e0bd8b7fc7fff02fb9629c9cd245c056b27f06e9973f5f2d3fb44abL295-R419) [[3]](diffhunk://#diff-3e4602d91e0bd8b7fc7fff02fb9629c9cd245c056b27f06e9973f5f2d3fb44abL315-R447) [[4]](diffhunk://#diff-3e4602d91e0bd8b7fc7fff02fb9629c9cd245c056b27f06e9973f5f2d3fb44abL324-R461)

Closes #127 