### PR TITLE
ci: remove pr greet (not working)

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,22 +11,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  pr-greeting:
-    name: PR Greeting
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Thank you for your contribution! cc @plazen/reviewers @andrinoff'
-            })
-
   issue-triage:
     name: Issue Triage
     if: github.event_name == 'issues'


### PR DESCRIPTION
This pull request removes the automated PR greeting job from the GitHub Actions workflow configuration. The workflow will no longer post a greeting comment when a pull request is opened.