### PR TITLE
docs(license): update year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Plazen
+Copyright (c) 2026 Plazen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request makes a minor update to the `LICENSE` file, updating the copyright year.

- Updated the copyright year from 2025 to 2026 in the `LICENSE` file.