### PR TITLE
fix(emailTemplate): removed text-align to center

### DIFF
--- a/src/lib/emailTemplate.ts
+++ b/src/lib/emailTemplate.ts
@@ -352,7 +352,7 @@ export function generateEmailTemplate(options: EmailTemplateOptions): string {
             <td style="background-color: #0f1217; border-radius: 12px; padding: 40px; text-align: left; border: 1px solid rgba(255, 255, 255, 0.1); box-shadow: 0 4px 24px rgba(0,0,0,0.2);">
 
               <!-- Content -->
-              <div style="text-align: center;">
+              <div style="text-align: left;">
                 ${body}
               </div>
 


### PR DESCRIPTION
## Description

Removes the title from the email and makes the text aligned with the left side, rather than the center (looks bad)

## Type of Change

<!-- Please check the relevant option(s) by placing an 'x' in the brackets. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI change
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update
- [ ] 🔧 Configuration/build change

## Checklist

<!-- Please check all that apply by placing an 'x' in the brackets. -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added/updated comments for hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`npm run test`)
- [x] The build passes locally (`npm run build`)
- [x] I have signed the CLA (will be prompted automatically if needed)